### PR TITLE
docs: 論文タイトルを正しいものに更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🎉 初回リリース
 
-Kawaii Voice Changerの最初の公式リリースです。論文「Finding Kawaii」（arXiv:2507.06235）の研究成果に基づいた、声を「可愛く」変換するデスクトップアプリケーションです。
+Kawaii Voice Changerの最初の公式リリースです。論文「Super Kawaii Vocalics: Amplifying the "Cute" Factor in Computer Voice」（arXiv:2507.06235）の研究成果に基づいた、声を「可愛く」変換するデスクトップアプリケーションです。
 
 ### ✨ 主な機能
 
@@ -92,7 +92,7 @@ Kawaii Voice Changerの最初の公式リリースです。論文「Finding Kawa
 
 ### 🙏 謝辞
 
-- 論文「Finding Kawaii」の著者の皆様
+- 論文「Super Kawaii Vocalics: Amplifying the "Cute" Factor in Computer Voice」の著者の皆様
 - WORLD Vocoderの開発者 森勢将雅様
 - オープンソースコミュニティの皆様
 

--- a/docs/kawaii-voice-research-report.md
+++ b/docs/kawaii-voice-research-report.md
@@ -1,7 +1,7 @@
 # 可愛い声の再現実験ソフトウェア開発に関する調査レポート
 
 ## 概要
-本レポートは、論文「Finding Kawaii: A Study of Kawaii Vocal Aesthetics in Modern Japanese Popular Music」（arXiv:2507.06235）の実験を再現するためのソフトウェア開発に向けた技術調査結果をまとめたものです。
+本レポートは、論文「Super Kawaii Vocalics: Amplifying the "Cute" Factor in Computer Voice」（arXiv:2507.06235）の実験を再現するためのソフトウェア開発に向けた技術調査結果をまとめたものです。
 
 ## 論文の概要
 - **研究内容**: 音声の基本周波数（F0）とフォルマント周波数を操作することで「可愛い声」のスイートスポットを見つける研究

--- a/docs/requirements-specification.md
+++ b/docs/requirements-specification.md
@@ -3,7 +3,7 @@
 ## 1. プロジェクト概要
 
 ### 1.1 背景
-論文「Finding Kawaii: A Study of Kawaii Vocal Aesthetics in Modern Japanese Popular Music」（arXiv:2507.06235）の研究成果に基づき、音声の基本周波数（F0）とフォルマント周波数（F1-F3）を調整することで「可愛い声」のスイートスポットを探索できるソフトウェアを開発する。
+論文「Super Kawaii Vocalics: Amplifying the "Cute" Factor in Computer Voice」（arXiv:2507.06235）の研究成果に基づき、音声の基本周波数（F0）とフォルマント周波数（F1-F3）を調整することで「可愛い声」のスイートスポットを探索できるソフトウェアを開発する。
 
 ### 1.2 目的
 - 音声ファイルの基本周波数とフォルマント周波数をリアルタイムで調整


### PR DESCRIPTION
## 概要
- すべてのドキュメントファイルで参照している論文タイトルを正しいものに更新しました
- 「Finding Kawaii」から「Super Kawaii Vocalics: Amplifying the 'Cute' Factor in Computer Voice」に変更
- 論文の参照番号（arXiv:2507.06235）は変更ありません

## 変更内容
- `CHANGELOG.md`: v1.0.0リリースノートの論文タイトルを更新
- `docs/kawaii-voice-research-report.md`: 調査レポートのヘッダーの論文タイトルを更新
- `docs/requirements-specification.md`: プロジェクト背景セクションの論文タイトルを更新

## テスト計画
- [x] 古い論文タイトルのすべての出現箇所が更新されたことを確認
- [x] arXiv参照番号（2507.06235）が変更されていないことを確認
- [x] コードの変更はなく、ドキュメントの更新のみ

🤖 Generated with [Claude Code](https://claude.ai/code)