### PR TITLE
feat: CIにruffのlintとformatチェックを追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,13 @@
       "Bash(git pull:*)",
       "Bash(git stash:*)",
       "Bash(gh run watch:*)",
-      "Bash(gh release list:*)"
+      "Bash(gh release list:*)",
+      "Bash(git log:*)",
+      "Bash(gh run cancel:*)",
+      "Bash(gh issue view:*)",
+      "Bash(git checkout:*)",
+      "Bash(pip install:*)",
+      "Bash(pyenv global:*)"
     ],
     "deny": []
   }

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,35 @@
+name: Ruff
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ruff
+    
+    - name: Run Ruff format check
+      run: |
+        ruff format --check .
+    
+    - name: Run Ruff linter
+      run: |
+        ruff check .


### PR DESCRIPTION
## 概要
- #5 の対応としてruffのCI統合を実装
- 自動的なコード品質チェックのためのGitHub Actionsワークフローを追加
- CIパイプラインでlintとformatの両方のチェックを設定

## 詳細
このPRではmainおよびdevelopブランチへのプッシュとプルリクエスト時にruffチェックを実行するGitHub Actionsワークフローを追加します。ワークフローは以下を実行します：
- Ubuntu上でPython 3.12を使用して実行
- `ruff format --check`でコードフォーマットをチェック
- `ruff check`でlintチェックを実行

`pyproject.toml`の既存のruff設定は既に包括的で、コードベースはすべてのチェックに合格しています。

## テスト計画
- [x] GitHub Actionsワークフローファイルが有効であることを確認
- [x] ローカルでruffチェックが通ることを確認
- [ ] PR作成時にワークフローが正常に実行されることを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)